### PR TITLE
Update to use Stripe terminal SDK 2 (#62)

### DIFF
--- a/RNStripeTerminal.podspec
+++ b/RNStripeTerminal.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/theopolisme/react-native-stripe-terminal"
   s.license      = "MIT"
   s.author       = { "author" => "theo@theopatt.com" }
-  s.platform     = :ios, "7.0"
+  s.platform     = :ios, "11.0"
   s.source       = { :git => "https://github.com/theopolisme/react-native-stripe-terminal.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m}"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,5 @@ repositories {
 
 dependencies {
   implementation "com.facebook.react:react-native:+"
-  implementation "com.stripe:stripeterminal:1.0.0"
+  implementation "com.stripe:stripeterminal:2.1.0"
 }

--- a/android/src/main/java/com/reactnative_stripeterminal/Constants.java
+++ b/android/src/main/java/com/reactnative_stripeterminal/Constants.java
@@ -1,11 +1,12 @@
 package com.reactnative_stripeterminal;
 
-import com.stripe.stripeterminal.model.external.ConnectionStatus;
-import com.stripe.stripeterminal.model.external.DeviceType;
-import com.stripe.stripeterminal.model.external.PaymentIntent;
-import com.stripe.stripeterminal.model.external.PaymentIntentStatus;
-import com.stripe.stripeterminal.model.external.PaymentStatus;
-import com.stripe.stripeterminal.model.external.ReaderEvent;
+import com.stripe.stripeterminal.external.models.ConnectionStatus;
+import com.stripe.stripeterminal.external.models.DeviceType;
+import com.stripe.stripeterminal.external.models.DiscoveryMethod;
+import com.stripe.stripeterminal.external.models.PaymentIntent;
+import com.stripe.stripeterminal.external.models.PaymentIntentStatus;
+import com.stripe.stripeterminal.external.models.PaymentStatus;
+import com.stripe.stripeterminal.external.models.ReaderEvent;
 
 import java.util.HashMap;
 
@@ -39,6 +40,10 @@ public class Constants {
     public static final String EVENT_UPDATE_CHECK = "updateCheck";
     public static final String EVENT_READER_SOFTWARE_UPDATE_PROGRESS = "readerSoftwareUpdateProgress";
     public static final String EVENT_UPDATE_INSTALL = "updateInstall";
+    public static final String EVENT_DID_REPORT_AVAILABLE_UPDATE = "didReportAvailableUpdate";
+    public static final String EVENT_DID_START_INSTALLING_UPDATE = "didStartInstallingUpdate";
+    public static final String EVENT_DID_REPORT_UPDATE_PROGRESS = "didReportReaderSoftwareUpdateProgress";
+    public static final String EVENT_DID_FINISH_INSTALLING_UPDATE = "didFinishInstallingUpdate";
     public static final String EVENT_ABORT_INSTALL_COMPLETION = "abortInstallUpdateCompletion";
     public static final String EVENT_ABORT_CREATE_PAYMENT_COMPLETION = "abortCreatePaymentCompletion";
 
@@ -75,8 +80,8 @@ public class Constants {
     //Plugin Constants
     static{
         constants.put("DeviceTypeChipper2X", DeviceType.CHIPPER_2X.ordinal());
-        constants.put("DiscoveryMethodBluetoothScan",0);               //Not applicable for Android SDK
-        constants.put("DiscoveryMethodBluetoothProximity",0);          //Not applicable for Android SDK
+        constants.put("DiscoveryMethodBluetoothScan", DiscoveryMethod.BLUETOOTH_SCAN.ordinal());
+        constants.put("DiscoveryMethodBluetoothProximity", DiscoveryMethod.BLUETOOTH_SCAN.ordinal()); //Not applicable for Android SDK
         constants.put("PaymentIntentStatusRequiresPaymentMethod", PaymentIntentStatus.REQUIRES_PAYMENT_METHOD.ordinal());
         constants.put("PaymentIntentStatusRequiresConfirmation", PaymentIntentStatus.REQUIRES_CONFIRMATION.ordinal());
         constants.put("PaymentIntentStatusRequiresCapture", PaymentIntentStatus.REQUIRES_CAPTURE.ordinal());

--- a/android/src/main/java/com/reactnative_stripeterminal/RNStripeTerminalModule.java
+++ b/android/src/main/java/com/reactnative_stripeterminal/RNStripeTerminalModule.java
@@ -10,31 +10,31 @@ import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
-import com.stripe.stripeterminal.callable.Callback;
-import com.stripe.stripeterminal.callable.Cancelable;
-import com.stripe.stripeterminal.callable.ConnectionTokenCallback;
-import com.stripe.stripeterminal.callable.ConnectionTokenProvider;
-import com.stripe.stripeterminal.callable.DiscoveryListener;
-import com.stripe.stripeterminal.callable.PaymentIntentCallback;
-import com.stripe.stripeterminal.callable.ReaderCallback;
-import com.stripe.stripeterminal.callable.ReaderDisplayListener;
-import com.stripe.stripeterminal.callable.ReaderSoftwareUpdateCallback;
-import com.stripe.stripeterminal.callable.ReaderSoftwareUpdateListener;
-import com.stripe.stripeterminal.callable.TerminalListener;
+import com.stripe.stripeterminal.external.callable.Callback;
+import com.stripe.stripeterminal.external.callable.Cancelable;
+import com.stripe.stripeterminal.external.callable.ConnectionTokenCallback;
+import com.stripe.stripeterminal.external.callable.ConnectionTokenProvider;
+import com.stripe.stripeterminal.external.callable.DiscoveryListener;
+import com.stripe.stripeterminal.external.callable.PaymentIntentCallback;
+import com.stripe.stripeterminal.external.callable.ReaderCallback;
+import com.stripe.stripeterminal.external.callable.BluetoothReaderListener;
+import com.stripe.stripeterminal.external.callable.ReaderSoftwareUpdateCallback;
+import com.stripe.stripeterminal.external.callable.TerminalListener;
 import com.stripe.stripeterminal.log.LogLevel;
-import com.stripe.stripeterminal.model.external.ConnectionStatus;
-import com.stripe.stripeterminal.model.external.ConnectionTokenException;
-import com.stripe.stripeterminal.model.external.DeviceType;
-import com.stripe.stripeterminal.model.external.DiscoveryConfiguration;
-import com.stripe.stripeterminal.model.external.PaymentIntent;
-import com.stripe.stripeterminal.model.external.PaymentIntentParameters;
-import com.stripe.stripeterminal.model.external.PaymentStatus;
-import com.stripe.stripeterminal.model.external.Reader;
-import com.stripe.stripeterminal.model.external.ReaderDisplayMessage;
-import com.stripe.stripeterminal.model.external.ReaderEvent;
-import com.stripe.stripeterminal.model.external.ReaderInputOptions;
-import com.stripe.stripeterminal.model.external.ReaderSoftwareUpdate;
-import com.stripe.stripeterminal.model.external.TerminalException;
+import com.stripe.stripeterminal.external.models.ConnectionConfiguration.BluetoothConnectionConfiguration;
+import com.stripe.stripeterminal.external.models.ConnectionStatus;
+import com.stripe.stripeterminal.external.models.ConnectionTokenException;
+import com.stripe.stripeterminal.external.models.DiscoveryMethod;
+import com.stripe.stripeterminal.external.models.DiscoveryConfiguration;
+import com.stripe.stripeterminal.external.models.PaymentIntent;
+import com.stripe.stripeterminal.external.models.PaymentIntentParameters;
+import com.stripe.stripeterminal.external.models.PaymentStatus;
+import com.stripe.stripeterminal.external.models.Reader;
+import com.stripe.stripeterminal.external.models.ReaderDisplayMessage;
+import com.stripe.stripeterminal.external.models.ReaderEvent;
+import com.stripe.stripeterminal.external.models.ReaderInputOptions;
+import com.stripe.stripeterminal.external.models.ReaderSoftwareUpdate;
+import com.stripe.stripeterminal.external.models.TerminalException;
 import com.stripe.stripeterminal.Terminal;
 
 import java.sql.Wrapper;
@@ -49,7 +49,7 @@ import javax.annotation.Nullable;
 
 import static com.reactnative_stripeterminal.Constants.*;
 
-public class RNStripeTerminalModule extends ReactContextBaseJavaModule implements TerminalListener, ConnectionTokenProvider, ReaderDisplayListener, ReaderSoftwareUpdateListener, DiscoveryListener {
+public class RNStripeTerminalModule extends ReactContextBaseJavaModule implements TerminalListener, ConnectionTokenProvider, BluetoothReaderListener, DiscoveryListener {
     final static String TAG = RNStripeTerminalModule.class.getSimpleName();
     final static String moduleName = "RNStripeTerminal";
     Cancelable pendingDiscoverReaders = null;
@@ -143,7 +143,7 @@ public class RNStripeTerminalModule extends ReactContextBaseJavaModule implement
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZ");
         paymentIntentMap.putString(CREATED,simpleDateFormat.format(new Date(paymentIntent.getCreated())));
         paymentIntentMap.putInt(STATUS,paymentIntent.getStatus().ordinal());
-        paymentIntentMap.putInt(AMOUNT,paymentIntent.getAmount());
+        paymentIntentMap.putInt(AMOUNT,(int)paymentIntent.getAmount());
         paymentIntentMap.putString(CURRENCY,currency);
         WritableMap metaDataMap = Arguments.createMap();
         if(paymentIntent.getMetadata()!=null){
@@ -156,13 +156,13 @@ public class RNStripeTerminalModule extends ReactContextBaseJavaModule implement
     }
 
     @ReactMethod
-    public void discoverReaders(int deviceType, int method, int simulated) {
+    public void discoverReaders(int method, int simulated) {
         boolean isSimulated = simulated == 0?false:true;
         try {
-            DeviceType devType = DeviceType.values()[deviceType];
-            DiscoveryConfiguration discoveryConfiguration = new DiscoveryConfiguration(0, devType, isSimulated);
+//            DiscoveryMethod discMethod;
+//            discMethod = DiscoveryMethod.valueOf(DiscoveryMethod.BLUETOOTH_SCAN.);  // Our only discovery method for Android
+            DiscoveryConfiguration discoveryConfiguration = new DiscoveryConfiguration(0, DiscoveryMethod.BLUETOOTH_SCAN, isSimulated);
             Callback statusCallback = new Callback() {
-
                 @Override
                 public void onSuccess() {
                     pendingDiscoverReaders = null;
@@ -257,7 +257,7 @@ public class RNStripeTerminalModule extends ReactContextBaseJavaModule implement
         PaymentIntentCallback paymentIntentCallback = new PaymentIntentCallback() {
             @Override
             public void onSuccess(@Nonnull final PaymentIntent paymentIntent) {
-                pendingCreatePaymentIntent = Terminal.getInstance().collectPaymentMethod(paymentIntent, RNStripeTerminalModule.this
+                pendingCreatePaymentIntent = Terminal.getInstance().collectPaymentMethod(paymentIntent
                         , new PaymentIntentCallback() {
                             @Override
                             public void onSuccess(@Nonnull final PaymentIntent collectedIntent) {
@@ -490,7 +490,7 @@ public class RNStripeTerminalModule extends ReactContextBaseJavaModule implement
 
     @ReactMethod
     public void collectPaymentMethod(){
-        pendingCreatePaymentIntent = Terminal.getInstance().collectPaymentMethod(lastPaymentIntent, this, new PaymentIntentCallback() {
+        pendingCreatePaymentIntent = Terminal.getInstance().collectPaymentMethod(lastPaymentIntent, new PaymentIntentCallback() {
             @Override
             public void onSuccess(@Nonnull PaymentIntent paymentIntent) {
                 pendingCreatePaymentIntent = null;
@@ -513,7 +513,7 @@ public class RNStripeTerminalModule extends ReactContextBaseJavaModule implement
     }
 
     @ReactMethod
-    public void connectReader(String serialNumber){
+    public void connectReader(String serialNumber, String locationId){
         Reader selectedReader = null;
         if(discoveredReadersList!=null && discoveredReadersList.size()>0){
             for(Reader reader:discoveredReadersList){
@@ -526,7 +526,8 @@ public class RNStripeTerminalModule extends ReactContextBaseJavaModule implement
         }
 
         if(selectedReader!=null) {
-            Terminal.getInstance().connectReader(selectedReader, new ReaderCallback() {
+            BluetoothConnectionConfiguration config = new BluetoothConnectionConfiguration(locationId);
+            Terminal.getInstance().connectBluetoothReader(selectedReader, config, this, new ReaderCallback() {
                 @Override
                 public void onSuccess(@Nonnull Reader reader) {
                     sendEventWithName(EVENT_READER_CONNECTION, serializeReader(reader));
@@ -650,53 +651,15 @@ public class RNStripeTerminalModule extends ReactContextBaseJavaModule implement
     }
 
     @ReactMethod
-    public void installUpdate(){
-        pendingInstallUpdate = Terminal.getInstance().installUpdate(readerSoftwareUpdate,this, new Callback() {
-            @Override
-            public void onSuccess() {
-                sendEventWithName(EVENT_UPDATE_INSTALL,Arguments.createMap());
-                readerSoftwareUpdate = null;
-            }
-
-            @Override
-            public void onFailure(@Nonnull TerminalException e) {
-                WritableMap errorMap = Arguments.createMap();
-                errorMap.putString(ERROR,e.getErrorMessage());
-                sendEventWithName(EVENT_UPDATE_INSTALL,errorMap);
-            }
-        });
-    }
-
-    @ReactMethod
-    public void checkForUpdate(){
-        Terminal.getInstance().checkForUpdate(new ReaderSoftwareUpdateCallback() {
-            @Override
-            public void onSuccess(@Nullable ReaderSoftwareUpdate readerSoftwareUpdate) {
-                RNStripeTerminalModule.this.readerSoftwareUpdate = readerSoftwareUpdate;
-                sendEventWithName(EVENT_UPDATE_CHECK,serializeUpdate(readerSoftwareUpdate));
-            }
-
-            @Override
-            public void onFailure(@Nonnull TerminalException e) {
-                WritableMap errorMap = Arguments.createMap();
-                errorMap.putString(ERROR,e.getErrorMessage());
-                sendEventWithName(EVENT_UPDATE_CHECK,errorMap);
-            }
-        });
-    }
-
-    @ReactMethod
     public void getConnectionStatus(){
         ConnectionStatus status = Terminal.getInstance().getConnectionStatus();
-        WritableMap statusMap = Arguments.createMap();
-        statusMap.putInt(EVENT_CONNECTION_STATUS,status.ordinal());
+        sendEventWithName(EVENT_CONNECTION_STATUS, status.ordinal());
     }
 
     @ReactMethod
     public void getPaymentStatus(){
         PaymentStatus status = Terminal.getInstance().getPaymentStatus();
-        WritableMap statusMap = Arguments.createMap();
-        statusMap.putInt(EVENT_PAYMENT_STATUS,status.ordinal());
+        sendEventWithName(EVENT_PAYMENT_STATUS, status.ordinal());
     }
 
     @Override
@@ -767,6 +730,21 @@ public class RNStripeTerminalModule extends ReactContextBaseJavaModule implement
 
     @Override
     public void onReportReaderSoftwareUpdateProgress(float v) {
-        sendEventWithName(EVENT_READER_SOFTWARE_UPDATE_PROGRESS,new Float(v));
+        sendEventWithName(EVENT_DID_REPORT_UPDATE_PROGRESS,new Float(v));
+    }
+
+    @Override
+    public void onReportAvailableUpdate(ReaderSoftwareUpdate update) {
+        sendEventWithName(EVENT_DID_REPORT_AVAILABLE_UPDATE, serializeUpdate(update));
+    }
+
+    @Override
+    public void onFinishInstallingUpdate(ReaderSoftwareUpdate update, TerminalException e) {
+        sendEventWithName(EVENT_DID_FINISH_INSTALLING_UPDATE, serializeUpdate(update));
+    }
+
+    @Override
+    public void onStartInstallingUpdate(ReaderSoftwareUpdate update, Cancelable cancel) {
+        sendEventWithName(EVENT_DID_START_INSTALLING_UPDATE, serializeUpdate(update));
     }
 }

--- a/connectionService.js
+++ b/connectionService.js
@@ -24,11 +24,12 @@ export default function createConnectionService(StripeTerminal, options) {
 
     static DesiredReaderAny = "any";
 
-    constructor({ policy, deviceType, discoveryMode }) {
+    constructor({ policy, deviceType, discoveryMode, locationId }) {
       this.policy = policy;
       this.deviceType = deviceType || StripeTerminal.DeviceTypeChipper2X;
       this.discoveryMode =
         discoveryMode || StripeTerminal.DiscoveryMethodBluetoothProximity;
+      this.locationId = locationId
 
       if (STCS.Policies.indexOf(policy) === -1) {
         throw new Error(
@@ -69,7 +70,8 @@ export default function createConnectionService(StripeTerminal, options) {
       );
       if (foundReader) {
         connectionPromise = StripeTerminal.connectReader(
-          foundReader.serialNumber
+          foundReader.serialNumber,
+          this.locationId
         );
 
         // Otherwise, connect to best strength reader.
@@ -79,7 +81,8 @@ export default function createConnectionService(StripeTerminal, options) {
         this.desiredReader === STCS.DesiredReaderAny
       ) {
         connectionPromise = StripeTerminal.connectReader(
-          readers[0].serialNumber
+          readers[0].serialNumber,
+          this.locationId
         );
       }
 
@@ -116,7 +119,7 @@ export default function createConnectionService(StripeTerminal, options) {
       this.connect();
     };
 
-    async connect(serialNumber) {
+    async connect(serialNumber, locationId) {
       this.emitter.emit(
         STCS.EventLog,
         `Connecting to reader: "${serialNumber || "any"}"...`
@@ -139,16 +142,16 @@ export default function createConnectionService(StripeTerminal, options) {
       await StripeTerminal.abortDiscoverReaders(); // end any pending search
       await StripeTerminal.disconnectReader(); // cancel any existing non-matching reader
       return StripeTerminal.discoverReaders(
-        this.deviceType,
-        this.discoveryMode
+        this.discoveryMode,
+        0
       );
     }
 
     async discover() {
       await StripeTerminal.abortDiscoverReaders(); // end any pending search
       return StripeTerminal.discoverReaders(
-        this.deviceType,
-        this.discoveryMode
+        this.discoveryMode,
+        0
       );
     }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { NativeModules, NativeEventEmitter,Platform } from 'react-native';
+import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
 import createHooks from './hooks';
 import createConnectionService from './connectionService';
 
@@ -62,6 +62,7 @@ class StripeTerminal {
     this._createListeners([
       'log',
       'readersDiscovered',
+      'abortDiscoverReadersCompletion',
       'readerSoftwareUpdateProgress',
       'didRequestReaderInput',
       'didRequestReaderDisplayMessage',
@@ -70,6 +71,10 @@ class StripeTerminal {
       'didChangePaymentStatus',
       'didChangeConnectionStatus',
       'didReportUnexpectedReaderDisconnect',
+      'didReportAvailableUpdate',
+      'didStartInstallingUpdate',
+      'didReportReaderSoftwareUpdateProgress',
+      'didFinishInstallingUpdate'
     ]);
   }
 
@@ -100,7 +105,7 @@ class StripeTerminal {
   initialize({ fetchConnectionToken }) {
     this._fetchConnectionToken = fetchConnectionToken;
     return new Promise((resolve, reject)=>{
-    if(Platform.OS == "android"){
+    if(Platform.OS === "android"){
       RNStripeTerminal.initialize((status)=>{
         if(status.isInitialized === true){
           resolve()
@@ -115,9 +120,9 @@ class StripeTerminal {
   });
   }
 
-  discoverReaders(deviceType, method, simulated) {
-    return this._wrapPromiseReturn('readerDiscoveryCompletion', () => {
-      RNStripeTerminal.discoverReaders(deviceType, method, simulated);
+  discoverReaders(method, simulated) {
+    return this._wrapPromiseReturn('readersDiscovered', () => {
+      RNStripeTerminal.discoverReaders(method, simulated);
     });
   }
 
@@ -133,9 +138,9 @@ class StripeTerminal {
     })
   }
 
-  connectReader(serialNumber) {
+  connectReader(serialNumber, locationId) {
     return this._wrapPromiseReturn('readerConnection', () => {
-      RNStripeTerminal.connectReader(serialNumber);
+      RNStripeTerminal.connectReader(serialNumber, locationId);
     });
   }
 

--- a/ios/RNStripeTerminal.h
+++ b/ios/RNStripeTerminal.h
@@ -12,12 +12,13 @@
 #import "StripeTerminal.h"
 #endif
 
-@interface RNStripeTerminal : RCTEventEmitter <RCTBridgeModule, SCPConnectionTokenProvider, SCPDiscoveryDelegate, SCPReaderDisplayDelegate, SCPTerminalDelegate, SCPReaderSoftwareUpdateDelegate> {
+@interface RNStripeTerminal : RCTEventEmitter <RCTBridgeModule, SCPConnectionTokenProvider, SCPDiscoveryDelegate, SCPTerminalDelegate, SCPBluetoothReaderDelegate> {
 
     NSArray<SCPReader *> *readers;
     SCPReader *reader;
     SCPPaymentIntent *intent;
     SCPReaderSoftwareUpdate *update;
+    SCPCancelable *pendingReadPaymentMethod;
     SCPCancelable *pendingCreatePaymentIntent;
     SCPCancelable *pendingDiscoverReaders;
     SCPCancelable *pendingInstallUpdate;

--- a/ios/RNStripeTerminal.xcodeproj/project.pbxproj
+++ b/ios/RNStripeTerminal.xcodeproj/project.pbxproj
@@ -177,7 +177,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -220,7 +220,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -242,6 +242,7 @@
 					"$(SRCROOT)/../../../ios/Pods/StripeTerminal/Carthage/Build/iOS/StripeTerminal.framework/Headers",
 					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNStripeTerminal;
@@ -264,6 +265,7 @@
 					"$(SRCROOT)/../../../ios/Pods/StripeTerminal/Carthage/Build/iOS/StripeTerminal.framework/Headers",
 					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNStripeTerminal;

--- a/ios/RNStripeTerminal.xcodeproj/xcshareddata/xcschemes/RNStripeTerminal.xcscheme
+++ b/ios/RNStripeTerminal.xcodeproj/xcshareddata/xcschemes/RNStripeTerminal.xcscheme
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+               BuildableName = "libRNStripeTerminal.a"
+               BlueprintName = "RNStripeTerminal"
+               ReferencedContainer = "container:RNStripeTerminal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1BEE828C124E6416179B904A9F66D794"
+               BuildableName = "React"
+               BlueprintName = "React"
+               ReferencedContainer = "container:../../../ios/Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+            BuildableName = "libRNStripeTerminal.a"
+            BlueprintName = "RNStripeTerminal"
+            ReferencedContainer = "container:RNStripeTerminal.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "react-native-stripe-terminal",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,29 +1,59 @@
 {
-  "name": "react-native-stripe-terminal",
-  "title": "React Native Stripe Terminal",
-  "version": "1.1.0",
+  "_args": [
+    [
+      "git+https://github.com/mynorth/react-native-stripe-terminal.git#stripe-terminal-2",
+      "/Users/derek/react/geotix"
+    ]
+  ],
+  "_from": "git+https://github.com/mynorth/react-native-stripe-terminal.git#stripe-terminal-2",
+  "_id": "react-native-stripe-terminal@git+https://github.com/mynorth/react-native-stripe-terminal.git#94b4a8f857cc270a38dc34bb16f9a0640f311643",
+  "_inBundle": false,
+  "_integrity": "",
+  "_location": "/react-native-stripe-terminal",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "git",
+    "raw": "git+https://github.com/mynorth/react-native-stripe-terminal.git#stripe-terminal-2",
+    "rawSpec": "git+https://github.com/mynorth/react-native-stripe-terminal.git#stripe-terminal-2",
+    "saveSpec": "git+https://github.com/mynorth/react-native-stripe-terminal.git#stripe-terminal-2",
+    "fetchSpec": "https://github.com/mynorth/react-native-stripe-terminal.git",
+    "gitCommittish": "stripe-terminal-2"
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "git+https://github.com/mynorth/react-native-stripe-terminal.git#94b4a8f857cc270a38dc34bb16f9a0640f311643",
+  "_spec": "git+https://github.com/mynorth/react-native-stripe-terminal.git#stripe-terminal-2",
+  "_where": "/Users/derek/react/geotix",
+  "author": {
+    "name": "Theo Patt",
+    "email": "theo@theopatt.com"
+  },
+  "bugs": {
+    "url": "https://github.com/theopolisme/react-native-stripe-terminal/issues"
+  },
+  "deprecated": false,
   "description": "React Native Stripe Terminal",
+  "homepage": "https://github.com/theopolisme/react-native-stripe-terminal#readme",
+  "keywords": [
+    "react-native"
+  ],
+  "license": "MIT",
+  "licenseFilename": "LICENSE",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "name": "react-native-stripe-terminal",
+  "peerDependencies": {
+    "react": "^17.0.0",
+    "react-native": "^0.64.0"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/theopolisme/react-native-stripe-terminal.git",
     "baseUrl": "https://github.com/theopolisme/react-native-stripe-terminal"
   },
-  "keywords": [
-    "react-native"
-  ],
-  "author": {
-    "name": "Theo Patt",
-    "email": "theo@theopatt.com"
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "license": "MIT",
-  "licenseFilename": "LICENSE",
-  "readmeFilename": "README.md",
-  "peerDependencies": {
-    "react": "^16.2.0",
-    "react-native": "^0.52.0"
-  }
+  "title": "React Native Stripe Terminal",
+  "version": "2.0.0"
 }


### PR DESCRIPTION
* Update React and React Native dependencies

* Start on update to StripeTerminal 2.0 for iOS

* Revert peerDependencies versions

* Update iOS target versions

* It discovers and connects!

* Handle firmware update events

* Bump peer dependencies

* Update some method parameters, export new event

* Remove a non-existent event

* Update Stripe terminal dependency version in Android build config

* Update Android Native module to use Stripe SDK 2.1.0

* Add new update related events to Android

* Remove commented out code

* Use `sendEventWithName` in return from Android `getConnectionStatus` and
`getPaymentStatus` -- needs to match events returned from iOS module

* Update README